### PR TITLE
Test: host verification with SAN containing only an email

### DIFF
--- a/httpclient/src/test/java/org/apache/http/conn/ssl/CertificatesToPlayWith.java
+++ b/httpclient/src/test/java/org/apache/http/conn/ssl/CertificatesToPlayWith.java
@@ -550,4 +550,28 @@ public class CertificatesToPlayWith {
         "-----END CERTIFICATE-----"
         ).getBytes();
 
+    public final static byte[] CONTAINING_JUST_EMAIL_IN_SAN = (
+		"-----BEGIN CERTIFICATE-----\n"
+            + "MIIDpTCCAo2gAwIBAgIJANqkMEtlkelbMA0GCSqGSIb3DQEBCwUAMHAxCzAJBgNV\n"
+            + "BAYTAlVTMQswCQYDVQQIDAJWQTERMA8GA1UEBwwIU29tZUNpdHkxEjAQBgNVBAoM\n"
+            + "CU15Q29tcGFueTETMBEGA1UECwwKTXlEaXZpc2lvbjEYMBYGA1UEAwwPd3d3LmNv\n"
+            + "bXBhbnkuY29tMB4XDTE4MDIxNTA3MjkzMFoXDTIwMDIxNTA3MjkzMFowcDELMAkG\n"
+            + "A1UEBhMCVVMxCzAJBgNVBAgMAlZBMREwDwYDVQQHDAhTb21lQ2l0eTESMBAGA1UE\n"
+            + "CgwJTXlDb21wYW55MRMwEQYDVQQLDApNeURpdmlzaW9uMRgwFgYDVQQDDA93d3cu\n"
+            + "Y29tcGFueS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC4v6Oq\n"
+            + "Ua0goRVn1cmT7MOpJhXFm3A70bTpvJIRpEjtGIz99hb34/9r5AYyf1VhKyWmBq24\n"
+            + "XNcOJ59XOlyjjbm2Tl811ufTOdcNbPadoVBmMt4039OSUFpVb4wAw2XPWLTCG2h1\n"
+            + "HNj9GuFHmwcDsg5EiIRrhDGQm2LLLAGoe5PdReoMZCeeWzNWvKTCV14pyRzwQhJL\n"
+            + "F1OmzLYzovbPfB8LZVhQgDbLsh034FScivf2oKDB+NEzAEagNpnrFR0MFLWGYsu1\n"
+            + "nWD5RiZi78HFGiibmhH7QrEPfGlo2eofuUga6naoBUROqkmMCIL8n1HZ/Ur0oGny\n"
+            + "vQCj1AyrfOhuVC53AgMBAAGjQjBAMAsGA1UdDwQEAwIEMDATBgNVHSUEDDAKBggr\n"
+            + "BgEFBQcDATAcBgNVHREEFTATgRFlbWFpbEBleGFtcGxlLmNvbTANBgkqhkiG9w0B\n"
+            + "AQsFAAOCAQEAZ0IsqRrsEmJ6Fa9Yo6PQtrKJrejN2TTDddVgyLQdokzWh/25JFad\n"
+            + "NCMYPH5KjTUyKf96hJDlDayjbKk1PMMhSZMU5OG9NOuGMH/dQttruG1ojse7KIKg\n"
+            + "yHDQrfq5Exxgfa7CMHRKAoTCY7JZhSLyVbTMVhmGfuUDad/RA86ZisXycp0ZmS97\n"
+            + "qDkAmzFL0sL0ZUWNNUh4ZUWvCUZwiuN08z70NjGqXMTDCf68p3SYxbII0xTfScgf\n"
+            + "aQ/A/hD7IbGGTexeoTwpEj01DNvefbQV6//neo32/R5XD0D5jn3TCgZcMThA6H3a\n"
+            + "VkEghVg+s7uMfL/UEebOBQWXQJ/uVoknMA==\n"
+            + "-----END CERTIFICATE-----"
+		).getBytes();
 }

--- a/httpclient/src/test/java/org/apache/http/conn/ssl/TestDefaultHostnameVerifier.java
+++ b/httpclient/src/test/java/org/apache/http/conn/ssl/TestDefaultHostnameVerifier.java
@@ -313,4 +313,16 @@ public class TestDefaultHostnameVerifier {
         }
     }
 
+
+    @Test
+    public void testSubjectAltEmailOnly() throws Exception {
+        final CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        final InputStream in = new ByteArrayInputStream(CertificatesToPlayWith.CONTAINING_JUST_EMAIL_IN_SAN);
+        final X509Certificate x509 = (X509Certificate) cf.generateCertificate(in);
+
+        Assert.assertEquals("CN=www.company.com, OU=MyDivision, O=MyCompany, L=SomeCity, ST=VA, C=US",
+            x509.getSubjectDN().getName());
+
+        impl.verify("www.company.com", x509);
+    }
 }


### PR DESCRIPTION
Commit 6e4759800fe8a82ee1e9f (https://issues.apache.org/jira/browse/HTTPCLIENT-1802) changed the behavior of the host name verification. In the new version a certificate which contains a CN and only an email in the SAN results in the following exception. 

```
javax.net.ssl.SSLPeerUnverifiedException: Certificate for <www.company.com> doesn't match any of the subject alternative names: [email@example.com]
```
Is this behavior correct? As I'm just a mere user I do not know if this behavior is correct.


Generate the certificate:
```
[req]
distinguished_name = req_distinguished_name
prompt = no
x509_extensions = v3_req
[req_distinguished_name]
C = US
ST = VA
L = SomeCity
O = MyCompany
OU = MyDivision
CN = www.company.com
[v3_req]
keyUsage = keyEncipherment, dataEncipherment
extendedKeyUsage = serverAuth
subjectAltName = @alt_names
[alt_names]
email = email@example.com
```

```
openssl req -x509 -nodes -days 730 -newkey rsa:2048 -keyout cert.pem -out cert.pem -config req.conf -extensions 'v3_req'
```

**Resources**
- https://tools.ietf.org/html/rfc5280#section-4.2.1.6
https://tools.ietf.org/html/rfc6125#section-6.3
- https://tools.ietf.org/html/rfc3280
- https://support.citrix.com/article/CTX135602
- https://certsimple.com/blog/single-multi-domain-https-certificates-are-the-same-thing